### PR TITLE
Allow API consumer to manage control keys

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -2,8 +2,6 @@
 
 function RoonApiSourceSelection(roon, opts) {
     this._objs = {};
-    this._id = 1;
-    this.opts = Object.assign({}, opts);
 
     this._svc = roon.register_service("com.roonlabs.sourcecontrol:1", {
         subscriptions: [
@@ -34,16 +32,10 @@ function RoonApiSourceSelection(roon, opts) {
 }
 
 RoonApiSourceSelection.prototype.new_device = function(o) {
-    if (this.opts.self_managed_keys) {
-        if (!o.state.control_key) {
-            throw new Error('Must set control key when using self managed control keys');
-        }
-        if (this._objs[o.state.control_key]) {
-            throw new Error('Must set control key to unique id');
-        }
-    } else {
-        o.state.control_key = (this._id++).toString();
-    }
+    o.state.control_key = o.state.control_key || "1";
+
+    if (this._objs[o.state.control_key])
+        throw new Error('Must set control key to unique id');
     
     this._objs[o.state.control_key] = o;
     this._svc.send_continue_all('subscribe_controls', "Changed", { controls_added: [ o.state ] });

--- a/lib.js
+++ b/lib.js
@@ -1,8 +1,9 @@
 "use strict";
 
 function RoonApiSourceSelection(roon, opts) {
-    this._objs = [];
+    this._objs = {};
     this._id = 1;
+    this.opts = Object.assign({}, opts);
 
     this._svc = roon.register_service("com.roonlabs.sourcecontrol:1", {
         subscriptions: [
@@ -10,13 +11,13 @@ function RoonApiSourceSelection(roon, opts) {
                 subscribe_name:   "subscribe_controls",
                 unsubscribe_name: "unsubscribe_controls",
                 start: (req) => {
-                    req.send_continue("Subscribed", { controls: this._objs.reduce((p,e) => p.push(e.state) && p, []) });
+                    req.send_continue("Subscribed", { controls: Object.values(this._objs).reduce((p,e) => p.push(e.state) && p, []) });
                 }
             }
         ],
         methods: {
-            get_all: (req) =>{
-                req.send_complete("Success", { controls: this._objs.reduce((p,e) => p.push(e.state) && p, []) });
+            get_all: (req) => {
+                req.send_complete("Success", { controls: Object.values(this._objs).reduce((p,e) => p.push(e.state) && p, []) });
             },
             standby: (req) => {
                 var d = this._objs[req.body.control_key];
@@ -33,7 +34,17 @@ function RoonApiSourceSelection(roon, opts) {
 }
 
 RoonApiSourceSelection.prototype.new_device = function(o) {
-    o.state.control_key = (this._id++).toString();
+    if (this.opts.self_managed_keys) {
+        if (!o.state.control_key) {
+            throw new Error('Must set control key when using self managed control keys');
+        }
+        if (this._objs[o.state.control_key]) {
+            throw new Error('Must set control key to unique id');
+        }
+    } else {
+        o.state.control_key = (this._id++).toString();
+    }
+    
     this._objs[o.state.control_key] = o;
     this._svc.send_continue_all('subscribe_controls', "Changed", { controls_added: [ o.state ] });
     return {
@@ -45,7 +56,7 @@ RoonApiSourceSelection.prototype.new_device = function(o) {
             for (let x in state) if (o.state[x] !== state[x]) o.state[x] = state[x];
             this._svc.send_continue_all('subscribe_controls', "Changed", { controls_changed: [ o.state ] });
         }
-    }
+    };
 };
 
 exports = module.exports = RoonApiSourceSelection;


### PR DESCRIPTION
# Rationale
This is an API change to allow the API consumer to manage the keys. The rationale for this is to better support device that have dynamic/user editable source selection, such as with Logitech Harmony where user can create and delete activities (that represent a state of an AV system - which device are on, which input are used etc).

## Use of the revised API

### When creating the service:
The API consumer needs to declare up front the use of new behavior through the previously unused `opts` parameter:

`this.sourceControlService = new RoonApiSourceControl(this.roon, { self_managed_keys: true });
`
### When creating a control:
```
var device = svc_source_control.new_device({
    state: {
        control_key:      myControlKey,
        display_name:     'My source control',
        supports_standby: true,
        status:           'indeterminate'
    },
    convenience_switch: (request) => {
        var control_key = request.body.control_key;
        // ... do stuff
        request.send_complete('Success');
    },
    standby: (request) => {
        var control_key = request.body.control_key;
        // ... do stuff
        request.send_complete('Success');
    }
});
```
The difference from previous use is setting of `control_key` within the initial device state. Previously this was populated by the `new_device()` method.

The assumption above is that `myControlKey` is assured to a string form number that is unique within the extension and is probably persisted to facilitate management of a dynamic controls list also persisted in configuration. There is no requirement for persistence, however without persistence, the old form of the API is adequate.

## Backwards compatibility
When a control is created without options:
`this.sourceControlService = new RoonApiSourceControl(this.roon, {});
`
`this.sourceControlService = new RoonApiSourceControl(this.roon);
`
the API should continue to behave as before.
